### PR TITLE
CHANGED: rendering options to Data::Dump::Tree

### DIFF
--- a/lib/Buggable/Plugin/CPANTesters.pm6
+++ b/lib/Buggable/Plugin/CPANTesters.pm6
@@ -1,6 +1,5 @@
 unit class Buggable::Plugin::CPANTesters;
 use Data::Dump::Tree;
-use Data::Dump::Tree::ExtraRoles;
 use URI::Escape;
 use WWW;
 use Buggable::TempPage;
@@ -14,10 +13,28 @@ multi method irc-to-me (
     my $res = jget $url orelse return "Cound not find that ID or API is down."
         ~ " Try manually: $url";
 
+    # I don't think you need to use the ExtraRoles module, removed it
+    # without comments this is just two or three lines long
+
+    # hash prettier displays as 'key: value'
+    my role ZR { multi method get_elements (Hash:D $h) { $h.sort(*.key)>>.kv.map: -> ($k, $v) {$k, ': ', $v} } }
+
+    # giving a tile is a good idea for looks
+    my $ddt_res = get_dump :title<Result:>, $res,
+
+                           # UnicodeGlyph is the default in the latest ddt version if you want to remove it
+                           :!color, :does[ZR, DDTR::UnicodeGlyphs],
+
+                           # remove the type and address; they only add noise in this case
+                           :!display_info,
+
+                           # I notice that output is further wrapped after generation by another
+                           # tool, let ddt limit rendering length to avoid wrongly double wrapped text
+                           # you may have to lower the value
+                           :width(120) ;
+
     "\x[2]$res<distribution><name>\x[2]"
     ~ ":ver(\x[2]$res<distribution><version>\x[2])"
     ~ " test result \x[2]$res<result><grade>.uc()\x[2]. See more at "
-    ~ temp-page :ext<.txt>, Data::Dump::Tree.new(
-        :!color, :does[DDTR::UnicodeGlyphs],
-    ).get_dump: $res, :!color;
+    ~ temp-page :ext<.txt>, $ddt_res
 }


### PR DESCRIPTION
Hi,

patch attached but since I don't see how to test your module, I also tested  in the code below which you can use if you want to fiddle outside your module.

```
use Data::Dump::Tree ;

use JSON::Tiny ;

my $JSON =
Q<<< 
{  
   "created":"2017-07-05T13:15:09Z",
   "distribution":{  
      "name":"Proc::Q",
      "version":"1.001003"
   },
   "environment":{  
      "language":{  
         "archname":"x86_64-linux",
         "backend":{  
            "engine":"moar",
            "version":"2017.06.29.ga.51.ba.62"
         },
         "implementation":"rakudo",
         "name":"Perl 6",
         "variables":{  
            "$*REPO.repo-chain":"\/home\/cpan\/.perl6 \/home\/cpan\/.rakudobrew\/moar-nom\/install\/share\/perl6\/site \/home\/cpan\/.rakudobrew\/moar-nom\/install\/share\/perl6\/vendor \/home\/cpan\/.rakudobrew\/moar-nom\/install\/share\/perl6 CompUnit::Repository::AbsolutePath<38642800> CompUnit::Repository::NQP<43019104> CompUnit::Repository::Perl5<43019144>"
         },
         "version":"2017.06.136.gd.5.d.3.bd.2"
      },
      "system":{  
         "osname":"linux",
         "osversion":"3.16.0.4.amd.64",
         "variables":{  
            "PATH":"\/home\/cpan\/bin:\/home\/cpan\/.rakudobrew\/bin:\/home\/cpan\/.rakudobrew\/moar-nom\/install\/share\/perl6\/site\/bin:\/home\/cpan\/perl5\/perlbrew\/bin:\/home\/cpan\/perl5\/perlbrew\/perls\/perl-5.26.0\/bin:\/usr\/local\/bin:\/usr\/bin:\/bin:\/usr\/local\/games:\/usr\/games",
            "PERLBREW_BASHRC_VERSION":"0.78",
            "PERLBREW_HOME":"\/home\/cpan\/.perlbrew",
            "PERLBREW_MANPATH":"\/home\/cpan\/perl5\/perlbrew\/perls\/perl-5.26.0\/man",
            "PERLBREW_PATH":"\/home\/cpan\/perl5\/perlbrew\/bin:\/home\/cpan\/perl5\/perlbrew\/perls\/perl-5.26.0\/bin",
            "PERLBREW_PERL":"perl-5.26.0",
            "PERLBREW_ROOT":"\/home\/cpan\/perl5\/perlbrew",
            "PERLBREW_VERSION":"0.78"
         }
      },
      "user_agent":"Zef::CPANReporter*"
   },
   "id":"F878354A-6183-11E7-89A5-C5F577A92919",
   "reporter":{  
      "email":"zoffix@cpan.org"
   },
   "result":{  
      "grade":"pass",
      "output":{  
         "test":"t\/01-basic.t .. okt\/02-tags.t ... okt\/03-in.t ..... okt\/04-batch.t .. okt\/meta.t ...... okAll tests successful.
Files=5, Tests=34,  21 wallclock secs
Result: PASS"
      }
   }
}
>>> ;

my $res = from-json($JSON) ;

my role ZR { multi method get_elements (Hash:D $h) { $h.sort(*.key)>>.kv.map: -> ($k, $v) {$k, ': ', $v} } }

my $ddt = get_dump :title<Result:>, $res, :!color, :does[ZR], :!display_info, :width(120) ;

$ddt.say ;
```
